### PR TITLE
ci(circle): fix node version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ aliases:
 defaults: &defaults
   working_directory: ~/ui-components
   docker:
-    - image: circleci/node:14.15.0
+    - image: cimg/node:14.15.0
 
 references:
   workspace_root: &workspace_root /tmp/workspace


### PR DESCRIPTION
Before this PR the outdated docker image was used, which has a wrong certificate chain