### PR TITLE
chore: fix release trigger branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,4 +171,4 @@ workflows:
             - build
           filters:
             branches:
-              only: next
+              only: master


### PR DESCRIPTION
## Summary

The `release` job has not been triggered because we still use the config from the `recommend` repository: https://github.com/algolia/ui-components/commit/0c616f296d59d3ccd6d2667846d42fc0cc899742