### PR TITLE
fix(highlight-vdom): remove UMD entry points and add CommonJS

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,7 @@
 module.exports = (api) => {
   const isTest = api.env('test');
-  const modules = isTest ? 'commonjs' : false;
+  const isCjs = api.env('cjs');
+  const modules = isTest || isCjs ? 'commonjs' : false;
   const targets = {};
 
   if (isTest) {

--- a/packages/highlight-vdom/package.json
+++ b/packages/highlight-vdom/package.json
@@ -11,10 +11,7 @@
   "source": "src/index.ts",
   "types": "dist/esm/index.d.ts",
   "module": "dist/esm/index.js",
-  "main": "dist/umd/index.js",
-  "umd:main": "dist/umd/index.js",
-  "unpkg": "dist/umd/index.js",
-  "jsdelivr": "dist/umd/index.js",
+  "main": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "dist/"

--- a/packages/highlight-vdom/package.json
+++ b/packages/highlight-vdom/package.json
@@ -11,7 +11,7 @@
   "source": "src/index.ts",
   "types": "dist/esm/index.d.ts",
   "module": "dist/esm/index.js",
-  "main": "dist/esm/index.js",
+  "main": "dist/cjs/index.js",
   "sideEffects": false,
   "files": [
     "dist/"
@@ -20,7 +20,8 @@
     "build:clean": "rm -rf ./dist",
     "build:esm": "babel src --root-mode upward --extensions '.ts,.tsx' --out-dir dist/esm --ignore '**/*/__tests__/'",
     "build:types": "tsc -p ./tsconfig.declaration.json --outDir ./dist/esm",
-    "build": "yarn build:clean && yarn build:esm && yarn build:types",
+    "build:cjs": "BABEL_ENV=cjs babel src --root-mode upward --extensions '.ts,.tsx' --out-dir dist/cjs --ignore '**/*/__tests__/'",
+    "build": "yarn build:clean && yarn build:esm && yarn build:cjs && yarn build:types",
     "prepare": "yarn build:esm && yarn build:types"
   },
   "dependencies": {


### PR DESCRIPTION
When we agreed not to expose an UMD build for `highlight-vdom` I forgot to remove the entry points for it. We don't need the package to be importable from CDNs.

~~Also replaced the `main` field with the ESM build. Right now, this is causing tools like ESLint and Jest not to find the package.~~

Edit: I now compile the package into CommonJS and use it for `main` for testing purposes—Jest doesn't natively works with ESM and setting it up requires Node 14, which we don't use in projects like InstantSearch.js.