### PR TITLE
fix(shared): remove UMD entry points and add CommonJS

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -17,8 +17,8 @@
       "maxSize": "750 kB"
     },
     {
-      "path": "packages/shared/dist/umd/index.js",
-      "maxSize": "450 B"
+      "path": "packages/shared/dist/esm/index.js",
+      "maxSize": "75 B"
     }
   ]
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,10 +11,7 @@
   "source": "src/index.ts",
   "types": "dist/esm/index.d.ts",
   "module": "dist/esm/index.js",
-  "main": "dist/umd/index.js",
-  "umd:main": "dist/umd/index.js",
-  "unpkg": "dist/umd/index.js",
-  "jsdelivr": "dist/umd/index.js",
+  "main": "dist/cjs/index.js",
   "sideEffects": false,
   "files": [
     "dist/"
@@ -23,8 +20,8 @@
     "build:clean": "rm -rf ./dist",
     "build:esm": "babel src --root-mode upward --extensions '.ts,.tsx' --out-dir dist/esm --ignore '**/*/__tests__/'",
     "build:types": "tsc -p ./tsconfig.declaration.json --outDir ./dist/esm",
-    "build:umd": "rollup --config",
-    "build": "yarn build:clean && yarn build:esm && yarn build:umd && yarn build:types",
+    "build:cjs": "BABEL_ENV=cjs babel src --root-mode upward --extensions '.ts,.tsx' --out-dir dist/cjs --ignore '**/*/__tests__/'",
+    "build": "yarn build:clean && yarn build:esm && yarn build:cjs && yarn build:types",
     "prepare": "yarn build:esm && yarn build:types"
   }
 }


### PR DESCRIPTION
There's no need to expose an UMD build for this package.

Additionally, we expose a CommonJS package for testing purposes (see https://github.com/algolia/ui-components/pull/7).