### PR TITLE
fix: add `@babel/runtime` as a dependency in relevant packages

### DIFF
--- a/packages/highlight-vdom/package.json
+++ b/packages/highlight-vdom/package.json
@@ -25,6 +25,7 @@
     "prepare": "yarn build:esm && yarn build:types"
   },
   "dependencies": {
-    "@algolia/ui-components-shared": "1.1.2"
+    "@algolia/ui-components-shared": "1.1.2",
+    "@babel/runtime": "^7.0.0"
   }
 }

--- a/packages/horizontal-slider-js/package.json
+++ b/packages/horizontal-slider-js/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@algolia/ui-components-horizontal-slider-vdom": "1.1.2",
+    "@babel/runtime": "^7.0.0",
     "preact": "^10.0.0"
   }
 }

--- a/packages/horizontal-slider-react/package.json
+++ b/packages/horizontal-slider-react/package.json
@@ -28,7 +28,8 @@
     "prepare": "yarn build:esm && yarn build:types"
   },
   "dependencies": {
-    "@algolia/ui-components-horizontal-slider-vdom": "1.1.2"
+    "@algolia/ui-components-horizontal-slider-vdom": "1.1.2",
+    "@babel/runtime": "^7.0.0"
   },
   "peerDependencies": {
     "react": ">= 16.8.0 < 18",

--- a/packages/horizontal-slider-vdom/package.json
+++ b/packages/horizontal-slider-vdom/package.json
@@ -28,6 +28,7 @@
     "prepare": "yarn build:esm && yarn build:types"
   },
   "dependencies": {
-    "@algolia/ui-components-shared": "1.1.2"
+    "@algolia/ui-components-shared": "1.1.2",
+    "@babel/runtime": "^7.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1089,6 +1089,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.0.0":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
+  integrity sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.8", "@babel/runtime@^7.6.3", "@babel/runtime@^7.8.4":
   version "7.14.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"


### PR DESCRIPTION
This PR adds `@babel/runtime` as a dependency in the packages which ESM builds include runtime helpers. This ensures consumer projects that don't already have `@babel/runtime` in their dependency tree don't error out when using ESM (e.g., InstantSearch.js, `recommend-js`).

This is the same strategy used in other popular UI libraries like React Spectrum and Material UI.