### PR TITLE
fix(babel): remove jsx pragma comment in output

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -32,5 +32,7 @@ module.exports = (api) => {
         },
       ],
     ],
+    // jsx is transpiled, so the comment should no longer be present in the final files
+    shouldPrintComment: (value) => !value.startsWith('* @jsx'),
   };
 };

--- a/babel.config.js
+++ b/babel.config.js
@@ -32,7 +32,7 @@ module.exports = (api) => {
         },
       ],
     ],
-    // jsx is transpiled, so the comment should no longer be present in the final files
+    // JSX is transpiled, so the comment should no longer be present in final files
     shouldPrintComment: (value) => !value.startsWith('* @jsx'),
   };
 };


### PR DESCRIPTION
This could cause issues in modern environments where the jsx environment is set to auto, which doesn't allow `@jsx` comments.

As the source file is compiled there won't be a difference in functionality.

```diff
diff --git a/packages/highlight-vdom/dist/esm/Highlight.js b/packages/highlight-vdom/dist/esm/Highlight.d.ts-pre
index bdba7e0..ab25463 100644
--- a/packages/highlight-vdom/dist/esm/Highlight.js
+++ b/packages/highlight-vdom/dist/esm/Highlight.js
@@ -1,8 +1,6 @@
 import _extends from "@babel/runtime/helpers/extends";
 import _objectWithoutProperties from "@babel/runtime/helpers/objectWithoutProperties";
 var _excluded = ["parts", "highlightedTagName", "nonHighlightedTagName", "separator", "className", "classNames"];
-
-/** @jsx createElement */
 import { cx } from '@algolia/ui-components-shared';

 function createHighlightPartComponent(_ref) {
 ```