### PR TITLE
fix(types): complete used interface of JSX fallback

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,34 @@ jobs:
       - run:
           name: Type checking
           command: yarn run test:types
+  test_types_no_react:
+    <<: *defaults
+    steps:
+      - checkout
+      - run: *install_yarn_version
+      - restore_cache: *restore_yarn_cache
+      - run:
+          name: Remove React types
+          command: |
+            # This simulates @types/react not being installed
+            node -e "
+              fs.writeFileSync(
+                './package.json',
+                JSON.stringify(
+                  Object.assign(require('./package.json'), {
+                    resolutions: { '@types/react': 'file:./scripts/empty-package' },
+                  }),
+                  null,
+                  2
+                )
+              );
+            "
+            # not running the scripts, as they should not run for *-react
+            yarn install --ignore-scripts
+      - run:
+          name: Type checking
+          # build:types is used, as it's easier to ignore the React packages
+          command: yarn build:types --ignore '@algolia/*-react'
   test_unit:
     <<: *defaults
     steps:
@@ -152,10 +180,11 @@ workflows:
   ci:
     jobs:
       - build
+      - test_types
+      - test_types_no_react
       - test_lint:
           requires:
             - build
-      - test_types
       - test_unit:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ jobs:
       - run:
           name: Type checking
           # Using build:types instead of test:types, as it's easier to run only the VDOM types
-          command: yarn build:types --scope '@algolia/*-vdom'
+          command: yarn build:types --scope '@algolia/*-{shared,vdom}'
   test_unit:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,13 +116,16 @@ jobs:
       - run:
           name: Remove React types
           command: |
-            # This simulates @types/react not being installed
+            # This simulates @types/react and preact not being installed
             node -e "
               fs.writeFileSync(
                 './package.json',
                 JSON.stringify(
                   Object.assign(require('./package.json'), {
-                    resolutions: { '@types/react': 'file:./scripts/empty-package' },
+                    resolutions: { 
+                      '@types/react': 'file:./scripts/empty-package',
+                      'preact': 'file:./scripts/empty-package',
+                    },
                   }),
                   null,
                   2
@@ -133,8 +136,8 @@ jobs:
             yarn install --ignore-scripts
       - run:
           name: Type checking
-          # Using build:types instead of test:types, as it's easier to ignore the React packages
-          command: yarn build:types --ignore '@algolia/*-react'
+          # Using build:types instead of test:types, as it's easier to run only the VDOM types
+          command: yarn build:types --scope '@algolia/*-vdom'
   test_unit:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
       - run:
           name: Type checking
           command: yarn run test:types
-  test_types_no_react:
+  test_types_no_jsx_implementation:
     <<: *defaults
     steps:
       - checkout
@@ -133,7 +133,7 @@ jobs:
             yarn install --ignore-scripts
       - run:
           name: Type checking
-          # build:types is used, as it's easier to ignore the React packages
+          # Using build:types instead of test:types, as it's easier to ignore the React packages
           command: yarn build:types --ignore '@algolia/*-react'
   test_unit:
     <<: *defaults
@@ -181,7 +181,7 @@ workflows:
     jobs:
       - build
       - test_types
-      - test_types_no_react
+      - test_types_no_jsx_implementation
       - test_lint:
           requires:
             - build

--- a/packages/highlight-vdom/src/Highlight.tsx
+++ b/packages/highlight-vdom/src/Highlight.tsx
@@ -7,8 +7,8 @@ import {
   Renderer,
 } from '@algolia/ui-components-shared';
 
-// basic types to allow this file to compile without @types/react or preact
-// this is a minimal subset of the actual types, coming from the JSX namespace
+// Basic types to allow this file to compile without a JSX implementation.
+// This is a minimal subset of the actual types from the `JSX` namespace.
 interface IntrinsicElement extends JSX.IntrinsicAttributes {
   children?: ComponentChildren;
   className?: string;

--- a/packages/highlight-vdom/src/Highlight.tsx
+++ b/packages/highlight-vdom/src/Highlight.tsx
@@ -7,6 +7,23 @@ import {
   Renderer,
 } from '@algolia/ui-components-shared';
 
+// basic types to allow this file to compile without @types/react or preact
+// this is a minimal subset of the actual types, coming from the JSX namespace
+interface IntrinsicElement extends JSX.IntrinsicAttributes {
+  children?: ComponentChildren;
+  className?: string;
+}
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace JSX {
+    interface IntrinsicElements {
+      span: IntrinsicElement;
+      mark: IntrinsicElement;
+    }
+  }
+}
+
 type HighlightPartProps = {
   children: ComponentChildren;
   classNames: Partial<HighlightClassNames>;
@@ -78,17 +95,19 @@ export function createHighlightComponent({
     Fragment,
   });
 
-  return function Highlight({
-    parts,
-    highlightedTagName = 'mark',
-    nonHighlightedTagName = 'span',
-    separator = ', ',
-    className,
-    classNames = {},
-    ...props
-  }: HighlightProps) {
+  return function Highlight(props: HighlightProps) {
+    const {
+      parts,
+      highlightedTagName = 'mark',
+      nonHighlightedTagName = 'span',
+      separator = ', ',
+      className,
+      classNames = {},
+      ...rest
+    } = props;
+
     return (
-      <span {...props} className={cx(classNames.root, className)}>
+      <span {...rest} className={cx(classNames.root, className)}>
         {parts.map((part, partIndex) => {
           const isLastPart = partIndex === parts.length - 1;
 

--- a/packages/highlight-vdom/src/Highlight.tsx
+++ b/packages/highlight-vdom/src/Highlight.tsx
@@ -95,19 +95,17 @@ export function createHighlightComponent({
     Fragment,
   });
 
-  return function Highlight(props: HighlightProps) {
-    const {
-      parts,
-      highlightedTagName = 'mark',
-      nonHighlightedTagName = 'span',
-      separator = ', ',
-      className,
-      classNames = {},
-      ...rest
-    } = props;
-
+  return function Highlight({
+    parts,
+    highlightedTagName = 'mark',
+    nonHighlightedTagName = 'span',
+    separator = ', ',
+    className,
+    classNames = {},
+    ...props
+  }: HighlightProps) {
     return (
-      <span {...rest} className={cx(classNames.root, className)}>
+      <span {...props} className={cx(classNames.root, className)}>
         {parts.map((part, partIndex) => {
           const isLastPart = partIndex === parts.length - 1;
 

--- a/packages/horizontal-slider-vdom/src/HorizontalSlider.tsx
+++ b/packages/horizontal-slider-vdom/src/HorizontalSlider.tsx
@@ -1,5 +1,5 @@
 /** @jsx createElement */
-import { cx, Renderer } from '@algolia/ui-components-shared';
+import { ComponentChildren, cx, Renderer } from '@algolia/ui-components-shared';
 
 import {
   FrameworkProps,
@@ -7,6 +7,45 @@ import {
   HorizontalSliderTranslations,
   RecordWithObjectID,
 } from './types';
+
+// basic types to allow this file to compile without @types/react or preact
+// this is a minimal subset of the actual types, coming from the JSX namespace
+interface IntrinsicElement extends JSX.IntrinsicAttributes {
+  children?: ComponentChildren;
+
+  className?: string;
+  id?: string;
+  tabIndex?: string | number;
+  title?: string;
+
+  onClick?: (event: MouseEvent) => void;
+  onKeyDown?: (event: KeyboardEvent) => void;
+  onScroll?: (event: MouseEvent) => void;
+}
+
+interface IntrinsicSvgElement extends IntrinsicElement {
+  width?: string;
+  height?: string;
+  viewBox?: string;
+  fill?: string;
+  fillRule?: string;
+  clipRule?: string;
+  d?: string;
+}
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace JSX {
+    interface IntrinsicElements {
+      div: IntrinsicElement;
+      button: IntrinsicElement;
+      ol: IntrinsicElement;
+      li: IntrinsicElement;
+      svg: IntrinsicSvgElement;
+      path: IntrinsicSvgElement;
+    }
+  }
+}
 
 let lastHorizontalSliderId = 0;
 

--- a/packages/shared/src/Renderer.ts
+++ b/packages/shared/src/Renderer.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-empty-interface */
 // Prevents type errors when using without a JSX implementation
 // (e.g., Angular InstantSearch via InstantSearch.js)
 // In the future, this may be fixable by accepting a JSX generic to every type
@@ -7,9 +8,20 @@
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace JSX {
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface Element {}
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface IntrinsicAttributes {
+      key?: string | number | null;
+      ref?: unknown;
+    }
+
+    interface ElementChildrenAttribute {
+      children: ComponentChildren;
+    }
+
+    interface Element<TProps = any, TType = any> {
+      type: TType;
+      props: TProps;
+      key: string | number | null;
+    }
     interface IntrinsicElements {}
   }
 }

--- a/packages/shared/src/Renderer.ts
+++ b/packages/shared/src/Renderer.ts
@@ -17,11 +17,7 @@ declare global {
       children: ComponentChildren;
     }
 
-    interface Element<TProps = any, TType = any> {
-      type: TType;
-      props: TProps;
-      key: string | number | null;
-    }
+    interface Element extends VNode {}
     interface IntrinsicElements {}
   }
 }
@@ -71,7 +67,10 @@ export type ComponentProps<
 
 export type VNode<TProps = any> = {
   type: any;
-  props: TProps & { children: ComponentChildren; key?: any };
+  props: TProps & {
+    children: ComponentChildren;
+    key?: string | number | null;
+  };
 };
 
 export type Renderer = {

--- a/scripts/empty-package/index.d.ts
+++ b/scripts/empty-package/index.d.ts
@@ -1,0 +1,1 @@
+// this file allows empty-package to be an @types/ package

--- a/scripts/empty-package/index.d.ts
+++ b/scripts/empty-package/index.d.ts
@@ -1,1 +1,1 @@
-// this file allows empty-package to be an @types/ package
+// This file allows `empty-package` to be an `@types/` package

--- a/scripts/empty-package/package.json
+++ b/scripts/empty-package/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "empty-package",
+  "version": "0.0.0",
+  "description": "empty package, used in tests as an alias for @types/react"
+}

--- a/scripts/empty-package/package.json
+++ b/scripts/empty-package/package.json
@@ -1,5 +1,5 @@
 {
   "name": "empty-package",
   "version": "0.0.0",
-  "description": "empty package, used in tests as an alias for @types/react"
+  "description": "An empty package used in tests as an alias for @types/"
 }


### PR DESCRIPTION
This PR contains two commits:

[9d6ca6d](https://github.com/algolia/ui-components/pull/16/commits/9d6ca6d79be944ccf6f076f56ee6702f8ac1b13f): adds a new task to CI to test that types can run without an implementation of JSX

The ci failure is expected, as it is fixed in next commit

[89c98ef](https://github.com/algolia/ui-components/pull/16/commits/89c98ef82cfac71492dc4866a9662df8c495098e): fixes the types introduced in #13 further, to also implement all implicit usage of JSX

FX-1855