### PR TITLE
feat(shared): add array support to cx utility

### DIFF
--- a/packages/shared/src/__tests__/cx.test.ts
+++ b/packages/shared/src/__tests__/cx.test.ts
@@ -17,4 +17,16 @@ describe('cx', () => {
     expect(cx('')).toBe(undefined);
     expect(cx(false, undefined, null)).toBe(undefined);
   });
+
+  test('recursively concatenates arrays', () => {
+    expect(cx(['class1', 'class2'], ['class3', 'class4'])).toBe(
+      'class1 class2 class3 class4'
+    );
+    expect(cx(['class1', 'class2'], false && ['class3', 'class4'])).toBe(
+      'class1 class2'
+    );
+    expect(
+      cx(['class1', false && 'class2'], ['class3', false && 'class4'])
+    ).toBe('class1 class3');
+  });
 });

--- a/packages/shared/src/cx.ts
+++ b/packages/shared/src/cx.ts
@@ -1,9 +1,9 @@
-type classValue = string | undefined | boolean | null | number;
+type ClassValue = string | undefined | boolean | null | number;
 
-export function cx(...cssClasses: Array<classValue | classValue[]>) {
+export function cx(...cssClasses: Array<ClassValue | ClassValue[]>) {
   return (
     cssClasses
-      .reduce<classValue[]>((acc, className) => {
+      .reduce<ClassValue[]>((acc, className) => {
         if (Array.isArray(className)) {
           return acc.concat(className);
         }

--- a/packages/shared/src/cx.ts
+++ b/packages/shared/src/cx.ts
@@ -1,5 +1,15 @@
-export function cx(
-  ...classNames: Array<string | number | boolean | undefined | null>
-) {
-  return classNames.filter(Boolean).join(' ') || undefined;
+type classValue = string | undefined | boolean | null | number;
+
+export function cx(...cssClasses: Array<classValue | classValue[]>) {
+  return (
+    cssClasses
+      .reduce<classValue[]>((acc, className) => {
+        if (Array.isArray(className)) {
+          return acc.concat(className);
+        }
+        return acc.concat([className]);
+      }, [])
+      .filter(Boolean)
+      .join(' ') || undefined
+  );
 }


### PR DESCRIPTION
This allows it to be easily used in InstantSearch.js and replace `classnames`