### PR TITLE
fix(cx): return a consistent string type

### DIFF
--- a/packages/highlight-vdom/src/__tests__/Highlight.test.tsx
+++ b/packages/highlight-vdom/src/__tests__/Highlight.test.tsx
@@ -12,7 +12,9 @@ describe('Highlight', () => {
 
     expect(container).toMatchInlineSnapshot(`
       <div>
-        <span />
+        <span
+          class=""
+        />
       </div>
     `);
   });
@@ -32,7 +34,9 @@ describe('Highlight', () => {
 
     expect(container).toMatchInlineSnapshot(`
       <div>
-        <span>
+        <span
+          class=""
+        >
           <mark>
             te
           </mark>
@@ -66,7 +70,9 @@ describe('Highlight', () => {
 
     expect(container).toMatchInlineSnapshot(`
       <div>
-        <span>
+        <span
+          class=""
+        >
           <mark>
             te
           </mark>
@@ -103,7 +109,9 @@ describe('Highlight', () => {
 
     expect(container).toMatchInlineSnapshot(`
       <div>
-        <span>
+        <span
+          class=""
+        >
           <strong>
             te
           </strong>
@@ -145,7 +153,9 @@ describe('Highlight', () => {
 
     expect(container).toMatchInlineSnapshot(`
       <div>
-        <span>
+        <span
+          class=""
+        >
           <strong>
             te
           </strong>

--- a/packages/shared/src/__tests__/cx.test.ts
+++ b/packages/shared/src/__tests__/cx.test.ts
@@ -13,9 +13,9 @@ describe('cx', () => {
     expect(cx('class1', false, undefined, null)).toBe('class1');
   });
 
-  test('returns `undefined` when empty', () => {
-    expect(cx('')).toBe(undefined);
-    expect(cx(false, undefined, null)).toBe(undefined);
+  test('returns `""` when empty', () => {
+    expect(cx('')).toBe('');
+    expect(cx(false, undefined, null)).toBe('');
   });
 
   test('recursively concatenates arrays', () => {

--- a/packages/shared/src/__tests__/cx.test.ts
+++ b/packages/shared/src/__tests__/cx.test.ts
@@ -13,7 +13,7 @@ describe('cx', () => {
     expect(cx('class1', false, undefined, null)).toBe('class1');
   });
 
-  test('returns `""` when empty', () => {
+  test('returns an empty string when falsy', () => {
     expect(cx('')).toBe('');
     expect(cx(false, undefined, null)).toBe('');
   });

--- a/packages/shared/src/cx.ts
+++ b/packages/shared/src/cx.ts
@@ -1,15 +1,13 @@
 type ClassValue = string | undefined | boolean | null | number;
 
 export function cx(...cssClasses: Array<ClassValue | ClassValue[]>) {
-  return (
-    cssClasses
-      .reduce<ClassValue[]>((acc, className) => {
-        if (Array.isArray(className)) {
-          return acc.concat(className);
-        }
-        return acc.concat([className]);
-      }, [])
-      .filter(Boolean)
-      .join(' ') || undefined
-  );
+  return cssClasses
+    .reduce<ClassValue[]>((acc, className) => {
+      if (Array.isArray(className)) {
+        return acc.concat(className);
+      }
+      return acc.concat([className]);
+    }, [])
+    .filter(Boolean)
+    .join(' ');
 }


### PR DESCRIPTION
This has a downside that if you call cx with values that are all falsy, an empty class will be written, but upside that you can rely on string manipulation later if needed.

This changes the snapshot of highlight, but not the real life usage, as that's called with a string that definitely exists.

This isn't a breaking change in my opinion, as an empty className and no className act identical, and this solution is much simpler than #20 or changing all code related to classNames in InstantSearch to have every key optional (even if they actually aren't going to be undefined)

For reference, the `classnames` package is also typed to always return a string.

closes #20