### PR TITLE
ci(shipjs): publish packages topographically

### DIFF
--- a/ship.config.js
+++ b/ship.config.js
@@ -4,12 +4,12 @@ module.exports = {
     // We rely on Lerna to bump our dependencies.
     packagesToBump: [],
     packagesToPublish: [
+      'packages/shared',
+      'packages/highlight-vdom',
+      'packages/horizontal-slider-vdom',
       'packages/horizontal-slider-js',
       'packages/horizontal-slider-react',
       'packages/horizontal-slider-theme',
-      'packages/horizontal-slider-vdom',
-      'packages/highlight-vdom',
-      'packages/shared',
     ],
   },
   publishCommand({ tag }) {

--- a/ship.config.js
+++ b/ship.config.js
@@ -1,16 +1,20 @@
+const shell = require('shelljs');
+
+const packages = JSON.parse(
+  shell.exec('yarn run --silent lerna list --toposort --json', {
+    silent: true,
+  })
+);
+const cwd = process.cwd();
+
 module.exports = {
   monorepo: {
     mainVersionFile: 'lerna.json',
     // We rely on Lerna to bump our dependencies.
     packagesToBump: [],
-    packagesToPublish: [
-      'packages/shared',
-      'packages/highlight-vdom',
-      'packages/horizontal-slider-vdom',
-      'packages/horizontal-slider-js',
-      'packages/horizontal-slider-react',
-      'packages/horizontal-slider-theme',
-    ],
+    packagesToPublish: packages.map(({ location }) =>
+      location.replace(cwd + '/', '')
+    ),
   },
   publishCommand({ tag }) {
     return `yarn publish --access public --tag ${tag}`;


### PR DESCRIPTION
If anything goes wrong, like npm being down in the middle of publishing, we want to have gotten to a valid state, only having packages that are depended on, not ones that depend on other packages that aren't yet published.

There's two commits here. First a manual reorder, then using lerna and shelljs (dependency of shipjs) to create the list.

After this is done here, we could either build this into shipjs or have this copied into other packages.

What this PR doesn't solve is if there's a failure midway, a rerun will still fail (as the first ones are already published). You'd still do that manually or publish a second patch.