### PR TITLE
fix(types): don't pollute globals with JSX

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,30 +114,16 @@ jobs:
       - run: *install_yarn_version
       - restore_cache: *restore_yarn_cache
       - run:
+          name: Build types
+          command: yarn build:types --scope '@algolia/*-{shared,vdom}'
+      - run:
           name: Remove React types
           command: |
-            # This simulates @types/react and preact not being installed
-            node -e "
-              fs.writeFileSync(
-                './package.json',
-                JSON.stringify(
-                  Object.assign(require('./package.json'), {
-                    resolutions: { 
-                      '@types/react': 'file:./scripts/empty-package',
-                      'preact': 'file:./scripts/empty-package',
-                    },
-                  }),
-                  null,
-                  2
-                )
-              );
-            "
-            # not running the scripts, as they should not run for *-react
+            yarn workspace @algolia/test-package remove-dependencies
             yarn install --ignore-scripts
       - run:
-          name: Type checking
-          # Using build:types instead of test:types, as it's easier to run only the VDOM types
-          command: yarn build:types --scope '@algolia/*-{shared,vdom}'
+          name: Type checking of usage
+          command: yarn workspace @algolia/test-package test
   test_unit:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,8 @@ workflows:
       - build
       - test_types
       - test_types_no_jsx_implementation
+          requires:
+            - build
       - test_lint:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,7 @@ workflows:
     jobs:
       - build
       - test_types
-      - test_types_no_jsx_implementation
+      - test_types_no_jsx_implementation:
           requires:
             - build
       - test_lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,9 +113,7 @@ jobs:
       - checkout
       - run: *install_yarn_version
       - restore_cache: *restore_yarn_cache
-      - run:
-          name: Build types
-          command: yarn build:types --scope '@algolia/*-{shared,vdom}'
+      - run: *restore_dist_folders
       - run:
           name: Remove React types
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - *attach_workspace
       - run: *install_yarn_version
       - restore_cache: *restore_yarn_cache
       - run: *restore_dist_folders

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "workspaces": [
     "packages/*",
-    "examples/*"
+    "examples/*",
+    "scripts/test-package"
   ],
   "scripts": {
     "build:clean": "lerna run build:clean --no-private",

--- a/packages/highlight-vdom/src/Highlight.tsx
+++ b/packages/highlight-vdom/src/Highlight.tsx
@@ -7,23 +7,6 @@ import {
   Renderer,
 } from '@algolia/ui-components-shared';
 
-// Basic types to allow this file to compile without a JSX implementation.
-// This is a minimal subset of the actual types from the `JSX` namespace.
-interface IntrinsicElement extends JSX.IntrinsicAttributes {
-  children?: ComponentChildren;
-  className?: string;
-}
-
-declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace JSX {
-    interface IntrinsicElements {
-      span: IntrinsicElement;
-      mark: IntrinsicElement;
-    }
-  }
-}
-
 type HighlightPartProps = {
   children: ComponentChildren;
   classNames: Partial<HighlightClassNames>;
@@ -95,15 +78,19 @@ export function createHighlightComponent({
     Fragment,
   });
 
-  return function Highlight({
-    parts,
-    highlightedTagName = 'mark',
-    nonHighlightedTagName = 'span',
-    separator = ', ',
-    className,
-    classNames = {},
-    ...props
-  }: HighlightProps) {
+  return function Highlight(userProps: HighlightProps) {
+    // Not destructured in function signature, to make sure it's not exposed in
+    // the type definition.
+    const {
+      parts,
+      highlightedTagName = 'mark',
+      nonHighlightedTagName = 'span',
+      separator = ', ',
+      className,
+      classNames = {},
+      ...props
+    } = userProps;
+
     return (
       <span {...props} className={cx(classNames.root, className)}>
         {parts.map((part, partIndex) => {

--- a/packages/horizontal-slider-vdom/src/HorizontalSlider.tsx
+++ b/packages/horizontal-slider-vdom/src/HorizontalSlider.tsx
@@ -1,5 +1,5 @@
 /** @jsx createElement */
-import { ComponentChildren, cx, Renderer } from '@algolia/ui-components-shared';
+import { cx, Renderer } from '@algolia/ui-components-shared';
 
 import {
   FrameworkProps,
@@ -7,45 +7,6 @@ import {
   HorizontalSliderTranslations,
   RecordWithObjectID,
 } from './types';
-
-// basic types to allow this file to compile without @types/react or preact
-// this is a minimal subset of the actual types, coming from the JSX namespace
-interface IntrinsicElement extends JSX.IntrinsicAttributes {
-  children?: ComponentChildren;
-
-  className?: string;
-  id?: string;
-  tabIndex?: string | number;
-  title?: string;
-
-  onClick?: (event: MouseEvent) => void;
-  onKeyDown?: (event: KeyboardEvent) => void;
-  onScroll?: (event: MouseEvent) => void;
-}
-
-interface IntrinsicSvgElement extends IntrinsicElement {
-  width?: string;
-  height?: string;
-  viewBox?: string;
-  fill?: string;
-  fillRule?: string;
-  clipRule?: string;
-  d?: string;
-}
-
-declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace JSX {
-    interface IntrinsicElements {
-      div: IntrinsicElement;
-      button: IntrinsicElement;
-      ol: IntrinsicElement;
-      li: IntrinsicElement;
-      svg: IntrinsicSvgElement;
-      path: IntrinsicSvgElement;
-    }
-  }
-}
 
 let lastHorizontalSliderId = 0;
 

--- a/packages/shared/src/Renderer.ts
+++ b/packages/shared/src/Renderer.ts
@@ -1,23 +1,10 @@
+/* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/no-empty-interface */
-// Prevents type errors when using without a JSX implementation
-// (e.g., Angular InstantSearch via InstantSearch.js)
-// In the future, this may be fixable by accepting a JSX generic to every type
-// or a `createRenderer` function that implies a JSX generic.
-//
-// This may be removable when this package is only used in an environment with JSX.
+
+// Ensure that the JSX namespace is available in this file and its dependents.
 declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace JSX {
-    interface IntrinsicAttributes {
-      key?: string | number | null;
-      ref?: unknown;
-    }
-
-    interface ElementChildrenAttribute {
-      children: ComponentChildren;
-    }
-
-    interface Element extends VNode {}
+    interface Element {}
     interface IntrinsicElements {}
   }
 }

--- a/scripts/test-package/package.json
+++ b/scripts/test-package/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@algolia/test-package",
+  "description": "used to test typescript",
+  "version": "0.0.0",
+  "private": true,
+  "license": "MIT",
+  "dependencies": {
+    "@algolia/ui-components-highlight-vdom": "1.2.1",
+    "@algolia/ui-components-horizontal-slider-vdom": "1.2.1",
+    "typescript": "4.2.4"
+  },
+  "scripts": {
+    "remove-dependencies": "node remove-dependencies.cjs",
+    "test": "yarn tsc usage.ts --noEmit"
+  }
+}

--- a/scripts/test-package/remove-dependencies.cjs
+++ b/scripts/test-package/remove-dependencies.cjs
@@ -1,0 +1,17 @@
+const fs = require('fs');
+
+fs.writeFileSync(
+  '../../package.json',
+  JSON.stringify(
+    Object.assign(require('../../package.json'), {
+      resolutions: {
+        preact: 'file:./scripts/empty-package',
+        '@types/react': 'file:./scripts/empty-package',
+        '@types/react-dom': 'file:./scripts/empty-package',
+        '@types/react-test-renderer': 'file:./scripts/empty-package',
+      },
+    }),
+    null,
+    2
+  )
+);

--- a/scripts/test-package/usage.ts
+++ b/scripts/test-package/usage.ts
@@ -1,0 +1,3 @@
+// every package that is usable without JSX type definition is listed here:
+import '@algolia/ui-components-highlight-vdom';
+import '@algolia/ui-components-horizontal-slider-vdom';


### PR DESCRIPTION
see https://github.com/algolia/ui-components/pull/13 and https://github.com/algolia/ui-components/pull/16

Essentially, in adding #16, we wanted to ensure everything built without JSX, but what we only want to do is ensure everything is _usable_ without JSX (like Angular InstantSearch, which I confirmed works with the new output of files, but you can definitely double check)

fixes #28 
future fix for https://github.com/algolia/instantsearch/issues/5853 once upstreamed

I think in the future as well it could be interesting to put this repo inside InstantSearch monorepo